### PR TITLE
Increase the pkcs5_keyivgen iterations to 1000 per the rubydoc recommendation.

### DIFF
--- a/lib/gibberish/aes.rb
+++ b/lib/gibberish/aes.rb
@@ -71,7 +71,7 @@ module Gibberish
 
     def setup_cipher(method, salt)
       cipher.send(method)
-      cipher.pkcs5_keyivgen(password, salt, 1)
+      cipher.pkcs5_keyivgen(password, salt, 1000)
     end
   end
 end


### PR DESCRIPTION
Hi there.

This commit message should be self explanatory:  

Increase the pkcs5_keyivgen iterations to 1000 per the rubydoc recommendation (http://www.ruby-doc.org/ruby-1.9/classes/OpenSSL/Cipher.html#M006488).

-Chris
