### PR TITLE
Added SHA512 digest support w/ docs and test

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -77,6 +77,9 @@ Defaults to 128 bit digest
     Gibberish::SHA256("somedata")
     #=> 87d149cb424c0387656f211d2589fb5b1e16229921309e98588419ccca8a7362
 
+    Gibberish::SHA512("somedata")
+    #=> a053441b6de662599ecb14c580d6637dcb856a66b2a40a952d39df772e47e98ea22f9e105b31463c5cf2472feae7649464fe89d99ceb6b0bc398a6926926f416
+
 [Find out more](http://mdp.github.com/gibberish/Gibberish/Digest.html)
 
 ## Run the tests

--- a/lib/gibberish/digest.rb
+++ b/lib/gibberish/digest.rb
@@ -6,17 +6,20 @@ module Gibberish
   #     Gibberish::MD5("data") #=> 8d777f385d3dfec8815d20f7496026dc
   #     Gibberish::SHA1("data") #=> a17c9aaa61e80a1bf71d0d850af4e5baa9800bbd
   #     Gibberish::SHA256("data") #=> 3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7
+  #     Gibberish::SHA512("data") #=> 77c7ce9a5d86bb386d443bb96390faa120633158699c8844c30b13ab0bf92760b7e4416aea397db91b4ac0e5dd56b8ef7e4b066162ab1fdc088319ce6defc876
   #
   # ## OpenSSL CLI Interop
   #
   #     echo -n 'data' | openssl dgst -sha1
   #     echo -n 'data' | openssl dgst -sha256
+  #     echo -n 'data' | openssl dgst -sha512
   #     echo -n 'data' | openssl dgst -md5
   #
   # is the same as
   #
   #     Gibberish::SHA1("data")
   #     Gibberish::SHA256("data")
+  #     Gibberish::SHA512("data")
   #     Gibberish::MD5("data")
   #
   class Digest
@@ -55,6 +58,23 @@ module Gibberish
       end
     end
 
+    # Returns the SHA512 digest for the data
+    #
+    # Shorcut alias: Gibberish::SHA512(data)
+    #
+    # @param [String] key
+    # @param [#to_s] data
+    # @param [Hash] options
+    # @option opts [Boolean] :binary (false) encode the data in binary, not Base64
+    def self.sha512(data, opts={})
+      data = data.to_s
+      if opts[:binary]
+        OpenSSL::Digest::SHA512.digest(data)
+      else
+        OpenSSL::Digest::SHA512.hexdigest(data)
+      end
+    end
+
     # Returns the MD5 digest for the data
     #
     # Shorcut alias: Gibberish::MD5(data)
@@ -79,6 +99,10 @@ module Gibberish
 
   def self.SHA256(data, opts={})
     Digest.sha256(data,opts)
+  end
+
+  def self.SHA512(data, opts={})
+    Digest.sha512(data,opts)
   end
 
   def self.MD5(data, opts={})

--- a/spec/digest_spec.rb
+++ b/spec/digest_spec.rb
@@ -14,4 +14,8 @@ describe "A variety of digest methods" do
     Gibberish::SHA256("password").must_equal("5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8")
   end
 
+  it "should work with SHA512" do
+    Gibberish::SHA512("password").must_equal("b109f3bbbc244eb82441917ed06d618b9008dd09b3befd1b5e07394c706a8bb980b1d7785e5976ec049b46df5f1326af5a2ea6d103fd07c95385ffab0cacbc86")
+  end
+
 end


### PR DESCRIPTION
Updated docs and tests to support SHA512 digest. Tested on RVM ruby-1.8.7-p352 [ x86_64 ] and ruby-1.9.2-p290 [ x86_64 ] on OS X 10.7.2.
