### PR TITLE
Adds a check to AES decrypt and throws an exception if data is too short

### DIFF
--- a/lib/gibberish/aes.rb
+++ b/lib/gibberish/aes.rb
@@ -55,6 +55,7 @@ module Gibberish
     alias :e :encrypt
 
     def decrypt(data, opts={})
+      raise ArgumentError, 'Data is too short' unless data.length >= 16
       data = Base64.decode64(data) unless opts[:binary]
       salt = data[8..15]
       data = data[16..-1]

--- a/spec/aes_spec.rb
+++ b/spec/aes_spec.rb
@@ -82,6 +82,10 @@ describe "the aes cipher" do
     FileUtils.cmp(source_file_path, decrypted_file.path).must_equal(true)
   end
 
+  it "should throw correct exception when decryption string is too short" do
+    assert_raises(ArgumentError) {@cipher.d("short")}
+  end
+
   describe 'stream encryption' do
 
     it 'encrypts a file' do


### PR DESCRIPTION
I noticed that this would fail with an awkward error so I thought an exception would be a little bit more helpful. 
