### PR TITLE
Fix deprecation of constant OpenSSL::Cipher::Cipher in ruby-2.4

### DIFF
--- a/lib/gibberish/aes.rb
+++ b/lib/gibberish/aes.rb
@@ -219,7 +219,7 @@ module Gibberish
       @password = password
       @size = size
       @mode = mode
-      @cipher = OpenSSL::Cipher::Cipher.new("aes-#{size}-#{mode}")
+      @cipher = OpenSSL::Cipher.new("aes-#{size}-#{mode}")
     end
 
     def encrypt(data, opts={})

--- a/lib/gibberish/rsa.rb
+++ b/lib/gibberish/rsa.rb
@@ -42,7 +42,7 @@ module Gibberish
 
       def initialize(key)
         @key = key
-        @cipher =  OpenSSL::Cipher::Cipher.new('aes-256-cbc')
+        @cipher =  OpenSSL::Cipher.new('aes-256-cbc')
       end
 
       def public_key


### PR DESCRIPTION
This PR fixes OpenSSL::Cipher::Cipher constant being deprecated in ruby-2.4